### PR TITLE
Modifications to support passing optional attributes in with each ref…

### DIFF
--- a/src/main/java/org/crossref/refmatching/Candidate.java
+++ b/src/main/java/org/crossref/refmatching/Candidate.java
@@ -40,7 +40,7 @@ public class Candidate {
     }
 
     public double getValidationSimilarity(Reference reference) {
-        return (reference instanceof StructuredReference)
+        return (reference.getType() == ReferenceType.STRUCTURED)
             ? getStructuredValidationSimilarity((StructuredReference) reference)
             : getStringValidationSimilarity(reference);
     }

--- a/src/main/java/org/crossref/refmatching/CandidateSelector.java
+++ b/src/main/java/org/crossref/refmatching/CandidateSelector.java
@@ -32,22 +32,23 @@ public class CandidateSelector {
      * @param refString The reference string to perform selection.
      * @param rows The number of rows to select for consideration
      * @param minScore The minimum score to consider a row a candidate
+     * @param headers Headers to passed via the CR-API client
      * 
      * @return A list of reference candidates
      */
     public List<Candidate> findCandidates(
-        String refString, int rows, double minScore, String mailTo, Map<String, String> headers) {
+        String refString, int rows, double minScore, Map<String, String> headers) {
         
         if (StringUtils.isEmpty(refString)) {
             return new ArrayList<>();
         }
 
-        JSONArray candidates = searchWorks(refString, rows, mailTo, headers);
+        JSONArray candidates = searchWorks(refString, rows, headers);
         return selectCandidates(refString, candidates, minScore);
     }
 
     private JSONArray searchWorks(
-        String refString, int rows, String mailTo, Map<String, String> headers) {
+        String refString, int rows, Map<String, String> headers) {
         
         // Invoke the client
         try {
@@ -56,9 +57,6 @@ public class CandidateSelector {
             Map<String, Object> args = new LinkedHashMap<>();
             args.put("rows", rows);
             args.put("query.bibliographic", refString);
-            if (!StringUtils.isEmpty(mailTo)) { // polite support
-                args.put("mailto", mailTo);
-            }
             
             // Invoke client for items
             Timer timer = new Timer();

--- a/src/main/java/org/crossref/refmatching/MainApp.java
+++ b/src/main/java/org/crossref/refmatching/MainApp.java
@@ -34,7 +34,7 @@ import org.json.JSONObject;
 public class MainApp {
     private static final String DEFAULT_API_SCHEME = "https";
     private static final String DEFAULT_API_HOST = "api.crossref.org";
-    private static final int DEFAULT_API_PORT = 8011;
+    private static final int DEFAULT_API_PORT = 0;
     private final static String CRAPI_KEY_FILE = ".crapi_key";
     private static final Logger logger = LogUtils.getLogger();
     
@@ -133,7 +133,6 @@ public class MainApp {
         options.addOption("ak", "key-file", true, "CR API key file");
         options.addOption("d", "delim", true, "Textual data delimiter");
         options.addOption("o", "out-file", true, "File to direct console output to");
-        options.addOption("m", "mail-to", true, "Mail-To option for 'polite' API call");
         options.addOption("h", "help", false, "Print help");
       
        // Parse/validate given arguments against defined options
@@ -206,10 +205,6 @@ public class MainApp {
 
             if (cmd.hasOption("d")) {
                 request.setDataDelimiter(cmd.getOptionValue("d"));
-            }
-
-            if (cmd.hasOption("m")) {
-               request.setMailTo(cmd.getOptionValue("m"));
             }
             
             /**
@@ -301,7 +296,7 @@ public class MainApp {
                 
                 outputItem.put("doi", m.getDOI());
                 outputItem.put("score", m.getScore());
-                outputItem.put("reference", m.getReference());
+                outputItem.put("reference", m.getQuery().getReference());
                 
                 writer.print(outputItem.toString());
             }

--- a/src/main/java/org/crossref/refmatching/MatchRequest.java
+++ b/src/main/java/org/crossref/refmatching/MatchRequest.java
@@ -1,6 +1,8 @@
 package org.crossref.refmatching;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -15,18 +17,30 @@ public class MatchRequest {
     public static final int DEFAULT_STR_ROWS = 100;
     public static final int DEFAULT_UNSTR_ROWS = 20;
     public static final String DEFAULT_DELIMITER = "\r?\n";
-
-    private final InputType inputType;
-    private final String inputValue;
+    
+    private InputType inputType;
+    private String inputValue;
     private double candidateMinScore = DEFAULT_CAND_MIN_SCORE;
     private double unstructuredMinScore = DEFAULT_UNSTR_MIN_SCORE;
     private double structuredMinScore = DEFAULT_STR_MIN_SCORE;
     private String dataDelimiter = DEFAULT_DELIMITER;
     private int unstructuredRows = DEFAULT_UNSTR_ROWS;
     private int structuredRows = DEFAULT_STR_ROWS;
-    private String mailTo = null;
-    private Map<String, String> headers = new HashMap<String, String>();
+    private final Map<String, String> headers = new HashMap<>();
+    private final List<ReferenceQuery> queries = new ArrayList<>();
     
+    /**
+     * Used when specifying queries directly in the request only.
+     */
+    public MatchRequest() {
+    }
+    
+    /**
+     * Used when including queries parsed from textual input data.
+     * 
+     * @param inputType The source of the textual data.
+     * @param inputValue The value corresponding to input type.
+     */
     public MatchRequest(InputType inputType, String inputValue) {
         this.inputType = inputType;
         this.inputValue = inputValue;
@@ -102,18 +116,20 @@ public class MatchRequest {
         this.structuredRows = structuredRows;
     }
 
-    public String getMailTo() {
-        return mailTo;
-    }
-
-    public void setMailTo(String mailTo) {
-        this.mailTo = mailTo;
-    }
-    
+   
+    /**
+     * Ad a header to be passed via the CR-API http client
+     * @param key
+     * @param value 
+     */
     public void addHeader(String key, String value) {
         this.headers.put(key, value);
     }
     
+    /**
+     * Set headers to be passed via the CR-API http client.
+     * @param headers Key/value pairs
+     */
     public void setHeaders(Map<String, String> headers) {
         this.headers.clear();
         if (headers != null) {
@@ -121,8 +137,28 @@ public class MatchRequest {
         }
     }
 
+    /**
+     * Get the headers to be passed via the CR-API client.
+     * @return A list of key/value pairs
+     */
     public Map<String, String> getHeaders() {
-        return new HashMap<String, String>(this.headers);
+        return new HashMap<>(this.headers);
+    }
+    
+    /**
+     * Add a query object to the request.
+     * @param query A query object
+     */
+    public void addQuery(ReferenceQuery query) {
+        queries.add(query);
+    }
+    
+    /**
+     * Get the list of queries associated with the request.
+     * @return A list of query objects
+     */
+    public List<ReferenceQuery> getQueries() {
+        return queries.subList(0, queries.size());
     }
 }
 

--- a/src/main/java/org/crossref/refmatching/Reference.java
+++ b/src/main/java/org/crossref/refmatching/Reference.java
@@ -13,4 +13,10 @@ public interface Reference {
      * @return A reference string
      */
     String getString();
+    
+    /**
+     * The basic type of the query.
+     * @return A query type
+     */
+    ReferenceType getType();
 }

--- a/src/main/java/org/crossref/refmatching/ReferenceLink.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceLink.java
@@ -6,22 +6,22 @@ package org.crossref.refmatching;
  * @author joe.aparo
  */
 public class ReferenceLink {
-    private String reference;
+    private ReferenceQuery query;
     private String doi;
     private double score;
 
-    public ReferenceLink(String reference, String doi, double score) {
-        this.reference = reference;
+    public ReferenceLink(ReferenceQuery query, String doi, double score) {
+        this.query = query;
         this.doi = doi;
         this.score = score;
     }
 
     /**
-     * Get the original reference that the item matched on.
+     * Get the original reference query that the item matched on.
      * @return A String representing the reference
      */
-    public String getReference() {
-        return reference;
+    public ReferenceQuery getQuery() {
+        return query;
     }
 
     /**

--- a/src/main/java/org/crossref/refmatching/ReferenceQuery.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceQuery.java
@@ -1,0 +1,34 @@
+package org.crossref.refmatching;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a distinct reference query object, which includes the
+ * original reference to query, and other values pertinent to the
+ * reference w/respect to the query. Optional values are provided
+ * so that caller-specified values (such as an internal correlation key)
+ * can be echoed back as part of the items returned in a match response.
+ * 
+ * @author joe.aparo
+ */
+public class ReferenceQuery {
+    private final Reference reference;
+    private final Map<String, Object> options = new HashMap<>();
+    
+    public ReferenceQuery(Reference reference) {
+        this.reference = reference;
+    }
+    
+    public Reference getReference() {
+        return reference;
+    }
+    
+    public Object getOption(String key) {
+        return options.get(key);
+    }
+    
+    public void putOption(String key, Object value) {
+        options.put(key, value);
+    }
+}

--- a/src/main/java/org/crossref/refmatching/ReferenceType.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceType.java
@@ -1,0 +1,12 @@
+package org.crossref.refmatching;
+
+/**
+ * Represents a reference classification, or type. Currently
+ * structured or unstructured.
+ * 
+ * @author joe.aparo
+ */
+public enum ReferenceType {
+    STRUCTURED,
+    UNSTRUCTURED
+}

--- a/src/main/java/org/crossref/refmatching/StructuredReference.java
+++ b/src/main/java/org/crossref/refmatching/StructuredReference.java
@@ -1,5 +1,6 @@
 package org.crossref.refmatching;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.json.JSONObject;
@@ -34,6 +35,18 @@ public class StructuredReference extends UnstructuredReference {
         return metadata.get(key);
     }
     
+    /**
+     * Return a copy of the internal map.
+     * 
+     * @return A map
+     */
+    public Map<String, String> getMap() {
+        Map<String, String> map = new HashMap<>();
+        map.putAll(metadata);
+        
+        return map;
+    }
+    
     private static String createRefStringFromMap(Map<String, String> metadata) {
         StringBuilder buf = new StringBuilder(500);
         for (String key : new String[]{"author", "article-title", "journal-title",
@@ -46,5 +59,9 @@ public class StructuredReference extends UnstructuredReference {
             buf.append(metadata.getOrDefault(key, ""));
         }
         return buf.toString().replaceAll(" +", " ").trim();
+    }
+    
+    public ReferenceType getType() {
+        return ReferenceType.STRUCTURED;
     }
 }

--- a/src/main/java/org/crossref/refmatching/UnstructuredReference.java
+++ b/src/main/java/org/crossref/refmatching/UnstructuredReference.java
@@ -25,4 +25,8 @@ public class UnstructuredReference implements Reference {
     public String toString() {
         return getString();
     }
+    
+    public ReferenceType getType() {
+        return ReferenceType.UNSTRUCTURED;
+    }
 }


### PR DESCRIPTION
A need that arose that required introducing new functionality into the reference matcher. The change does not impact the way the application is executed from the command line, but does provide new capability when executing the matcher programmatically. These changes have been placed into a new branch (CS-4135-pass-refquery-list), which was branched from the version of the branch you last tested with.

This new feature allows the caller to provide optional values, per individual reference to match. Values provided this way are simply fed back to the caller in the response. These optional properties will assist in tying results from the matcher back into the CS processing pipeline.

Internally, the change introduced a new construct (called a ReferenceQuery) which is now the unit on which the matcher operates. The new object simply contains a Reference to match, as before, as well as optional values that can be attached to it. The existing ReferenceLink result object now contains a ReferenceQuery, instead of a Reference.

The  -it / -i feature is still supported although now, input provided this way is simply mapped to the new implementation.  ReferenceQuery objects can be added to the MatchRequest programmatically as well, without having to use the inputType / inputValue feature, and these two approaches can be combined.

The reference model was extended a tiny bit, and more streamlining of logic in ReferenceMatcher was made possible by the changes. The private match methods now accept ReferenceQuery objects, which operate on the contained Reference. A ReferenceType enum was also introduced and is maintained in a reference to abstract away the notion of structured vs. unstructured from the class itself.

So it’s now:
    if (reference.getType() == ReferenceType.STRUCTURED) {…}
Versus:
    if (reference instanceof StructuredReference) {…}