### PR TITLE
Introduce ability to specify optional attributes per query. These val…

### DIFF
--- a/src/main/java/org/crossref/refmatching/CandidateSelector.java
+++ b/src/main/java/org/crossref/refmatching/CandidateSelector.java
@@ -41,18 +41,18 @@ public class CandidateSelector {
      * @return A list of candidates
      */
     public List<Candidate> findCandidates(Reference reference, int rows,
-            double minScore, String mailTo, Map<String, String> headers) {
+            double minScore, Map<String, String> headers) {
         String query = getQuery(reference);
         
         if (StringUtils.isEmpty(query)) {
             return new ArrayList<>();
         }
 
-        JSONArray candidates = searchWorks(query, rows, mailTo, headers);
+        JSONArray candidates = searchWorks(query, rows, headers);
         return selectCandidates(query, candidates, minScore);
     }
 
-    private JSONArray searchWorks(String refString, int rows, String mailTo,
+    private JSONArray searchWorks(String refString, int rows,
             Map<String, String> headers) {
         try {
             log.debug("API search for: " + refString);
@@ -60,9 +60,6 @@ public class CandidateSelector {
             Map<String, Object> args = new LinkedHashMap<>();
             args.put("rows", rows);
             args.put("query.bibliographic", refString);
-            if (!StringUtils.isEmpty(mailTo)) { // polite support
-                args.put("mailto", mailTo);
-            }
             
             // Invoke client for items
             Timer timer = new Timer();

--- a/src/main/java/org/crossref/refmatching/CandidateSelector.java
+++ b/src/main/java/org/crossref/refmatching/CandidateSelector.java
@@ -35,7 +35,6 @@ public class CandidateSelector {
      * @param rows The number of search items to consider as candidates
      * @param minScore The minimum relevance score to consider a search item
      * a candidate
-     * @param mailTo Polite mailTo
      * @param headers Additional headers to pass in the search request
      * 
      * @return A list of candidates

--- a/src/main/java/org/crossref/refmatching/MainApp.java
+++ b/src/main/java/org/crossref/refmatching/MainApp.java
@@ -144,8 +144,6 @@ public class MainApp {
         options.addOption("ak", "key-file", true, "CR API key file");
         options.addOption("d", "delim", true, "Textual data delimiter");
         options.addOption("o", "out-file", true, "Output file");
-        options.addOption("m", "mail-to", true,
-                "Mail-To option for 'polite' API call");
         options.addOption("h", "help", false, "Print help");
       
         // Parse/validate given arguments against defined options
@@ -170,7 +168,7 @@ public class MainApp {
                throw new RuntimeException("Input value not specified");
             }
 
-           // Validate given input type
+            // Validate given input type
             String typeCode = cmd.getOptionValue("it");
             InputType inputType = InputType.getByCode(typeCode);
             if (inputType == null) {
@@ -228,10 +226,6 @@ public class MainApp {
 
             if (cmd.hasOption("d")) {
                 request.setDataDelimiter(cmd.getOptionValue("d"));
-            }
-
-            if (cmd.hasOption("m")) {
-               request.setMailTo(cmd.getOptionValue("m"));
             }
             
             /**

--- a/src/main/java/org/crossref/refmatching/MatchRequest.java
+++ b/src/main/java/org/crossref/refmatching/MatchRequest.java
@@ -1,6 +1,5 @@
  package org.crossref.refmatching;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,54 +15,28 @@ public class MatchRequest {
     public static final double DEFAULT_STR_MIN_SCORE = 0.76;
     public static final int DEFAULT_STR_ROWS = 100;
     public static final int DEFAULT_UNSTR_ROWS = 20;
-    public static final String DEFAULT_DELIMITER = "\r?\n";
 
-    private InputType inputType;
-    private String inputValue;
     private double candidateMinScore = DEFAULT_CAND_MIN_SCORE;
     private double unstructuredMinScore = DEFAULT_UNSTR_MIN_SCORE;
     private double structuredMinScore = DEFAULT_STR_MIN_SCORE;
-    private String dataDelimiter = DEFAULT_DELIMITER;
     private int unstructuredRows = DEFAULT_UNSTR_ROWS;
     private int structuredRows = DEFAULT_STR_ROWS;
     private final Map<String, String> headers = new HashMap<String, String>();
-    private final List<ReferenceQuery> queries = new ArrayList<>();
-    
-    /**
-     * Used when specifying queries directly in the request only.
-     */
-    public MatchRequest() {
+    private final List<ReferenceData> references;
+
+    public MatchRequest(List<ReferenceData> references) {
+        this.references = references;
     }
 
-    /**
-     * Used when including queries parsed from textual input data.
-     * 
-     * @param inputType The source of the textual data.
-     * @param inputValue The value corresponding to input type.
-     */
-    public MatchRequest(InputType inputType, String inputValue) {
-        this.inputType = inputType;
-        this.inputValue = inputValue;
-    }
-
-    public MatchRequest(InputType inputType, String inputValue,
+    public MatchRequest(List<ReferenceData> references,
             double candidateMinScore, double unstructuredMinScore,
             double structuredMinScore, int unstructuredRows, int structuredRows) {
-        this.inputType = inputType;
+        this.references = references;
         this.candidateMinScore = candidateMinScore;
         this.unstructuredMinScore = unstructuredMinScore;
         this.structuredMinScore = structuredMinScore;
-        this.inputValue = inputValue;
         this.unstructuredRows = unstructuredRows;
         this.structuredRows = structuredRows;
-    }
-
-    public InputType getInputType() {
-        return inputType;
-    }
-
-     public String getInputValue() {
-        return inputValue;
     }
 
     public double getCandidateMinScore() {
@@ -88,14 +61,6 @@ public class MatchRequest {
 
     public void setStructuredMinScore(double structuredMinScore) {
         this.structuredMinScore = structuredMinScore;
-    }
-
-    public String getDataDelimiter() {
-        return dataDelimiter;
-    }
-
-    public void setDataDelimiter(String dataDelimiter) {
-        this.dataDelimiter = dataDelimiter;
     }
 
     public int getUnstructuredRows() {
@@ -142,20 +107,11 @@ public class MatchRequest {
         return new HashMap<>(this.headers);
     }
     
-    
-    /**
-     * Add a query object to the request.
-     * @param query A query object
-     */
-    public void addQuery(ReferenceQuery query) {
-        queries.add(query);
-    }
-    
     /**
      * Get the list of queries associated with the request.
      * @return A list of query objects
      */
-    public List<ReferenceQuery> getQueries() {
-        return queries.subList(0, queries.size());
+    public List<ReferenceData> getReferences() {
+        return references.subList(0, references.size());
     }
 }

--- a/src/main/java/org/crossref/refmatching/MatchRequest.java
+++ b/src/main/java/org/crossref/refmatching/MatchRequest.java
@@ -1,6 +1,8 @@
  package org.crossref.refmatching;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -16,17 +18,29 @@ public class MatchRequest {
     public static final int DEFAULT_UNSTR_ROWS = 20;
     public static final String DEFAULT_DELIMITER = "\r?\n";
 
-    private final InputType inputType;
-    private final String inputValue;
+    private InputType inputType;
+    private String inputValue;
     private double candidateMinScore = DEFAULT_CAND_MIN_SCORE;
     private double unstructuredMinScore = DEFAULT_UNSTR_MIN_SCORE;
     private double structuredMinScore = DEFAULT_STR_MIN_SCORE;
     private String dataDelimiter = DEFAULT_DELIMITER;
     private int unstructuredRows = DEFAULT_UNSTR_ROWS;
     private int structuredRows = DEFAULT_STR_ROWS;
-    private String mailTo = null;
     private final Map<String, String> headers = new HashMap<String, String>();
+    private final List<ReferenceQuery> queries = new ArrayList<>();
     
+    /**
+     * Used when specifying queries directly in the request only.
+     */
+    public MatchRequest() {
+    }
+
+    /**
+     * Used when including queries parsed from textual input data.
+     * 
+     * @param inputType The source of the textual data.
+     * @param inputValue The value corresponding to input type.
+     */
     public MatchRequest(InputType inputType, String inputValue) {
         this.inputType = inputType;
         this.inputValue = inputValue;
@@ -99,19 +113,20 @@ public class MatchRequest {
     public void setStructuredRows(int structuredRows) {
         this.structuredRows = structuredRows;
     }
-
-    public String getMailTo() {
-        return mailTo;
-    }
-
-    public void setMailTo(String mailTo) {
-        this.mailTo = mailTo;
-    }
     
+ /**
+     * Ad a header to be passed via the CR-API http client
+     * @param key
+     * @param value 
+     */
     public void addHeader(String key, String value) {
         this.headers.put(key, value);
     }
     
+    /**
+     * Set headers to be passed via the CR-API http client.
+     * @param headers Key/value pairs
+     */
     public void setHeaders(Map<String, String> headers) {
         this.headers.clear();
         if (headers != null) {
@@ -119,7 +134,28 @@ public class MatchRequest {
         }
     }
 
+    /**
+     * Get the headers to be passed via the CR-API client.
+     * @return A list of key/value pairs
+     */
     public Map<String, String> getHeaders() {
         return new HashMap<>(this.headers);
+    }
+    
+    
+    /**
+     * Add a query object to the request.
+     * @param query A query object
+     */
+    public void addQuery(ReferenceQuery query) {
+        queries.add(query);
+    }
+    
+    /**
+     * Get the list of queries associated with the request.
+     * @return A list of query objects
+     */
+    public List<ReferenceQuery> getQueries() {
+        return queries.subList(0, queries.size());
     }
 }

--- a/src/main/java/org/crossref/refmatching/MatchResponse.java
+++ b/src/main/java/org/crossref/refmatching/MatchResponse.java
@@ -55,10 +55,10 @@ public class MatchResponse {
                 r -> {
                     JSONObject result = new JSONObject();
                     result.put("reference",
-                            r.getReference().getType().equals(
+                            r.getQuery().getReference().getType().equals(
                                     ReferenceType.STRUCTURED) ?
-                            r.getReference().getMetadataAsJSON() :
-                            r.getReference().getFormattedString());
+                            r.getQuery().getReference().getMetadataAsJSON() :
+                            r.getQuery().getReference().getFormattedString());
                     result.put("DOI",
                             (r.getDOI() == null) ? JSONObject.NULL : r.getDOI());
                     result.put("score", r.getScore());

--- a/src/main/java/org/crossref/refmatching/ReferenceData.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceData.java
@@ -4,19 +4,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Represents a distinct reference query object, which includes the
- * original reference to query, and other values pertinent to the
- * reference w/respect to the query. Optional values are provided
- * so that caller-specified values (such as an internal correlation key)
- * can be echoed back as part of the items returned in a match response.
+ * Encapsulates the bibliographic reference and additional related information
+ * (optional). Additional information are not used for matching, but preserved
+ * and returned back in the response. Example use case is an internal correlation
+ * key.
  * 
- * @author joe.aparo
+ * @author Joe Aparo
  */
-public class ReferenceQuery {
+public class ReferenceData {
     private final Reference reference;
     private final Map<String, Object> options = new HashMap<>();
     
-    public ReferenceQuery(Reference reference) {
+    public ReferenceData(Reference reference) {
         this.reference = reference;
     }
     

--- a/src/main/java/org/crossref/refmatching/ReferenceLink.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceLink.java
@@ -7,11 +7,11 @@ package org.crossref.refmatching;
  */
 public class ReferenceLink {
     
-    private final ReferenceQuery query;
+    private final ReferenceData query;
     private final String doi;
     private final double score;
 
-    public ReferenceLink(ReferenceQuery query, String doi, double score) {
+    public ReferenceLink(ReferenceData query, String doi, double score) {
         this.query = query;
         this.doi = doi;
         this.score = score;
@@ -21,7 +21,7 @@ public class ReferenceLink {
      * Get the original reference query that the item matched on.
      * @return A String representing the reference
      */
-    public ReferenceQuery getQuery() {
+    public ReferenceData getQuery() {
         return query;
     }
 

--- a/src/main/java/org/crossref/refmatching/ReferenceLink.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceLink.java
@@ -7,23 +7,22 @@ package org.crossref.refmatching;
  */
 public class ReferenceLink {
     
-    private final Reference reference;
+    private final ReferenceQuery query;
     private final String doi;
     private final double score;
 
-    public ReferenceLink(Reference reference, String doi, double score) {
-        this.reference = reference;
+    public ReferenceLink(ReferenceQuery query, String doi, double score) {
+        this.query = query;
         this.doi = doi;
         this.score = score;
     }
 
     /**
-     * Get the original reference.
-     * 
-     * @return A reference
+     * Get the original reference query that the item matched on.
+     * @return A String representing the reference
      */
-    public Reference getReference() {
-        return reference;
+    public ReferenceQuery getQuery() {
+        return query;
     }
 
     /**

--- a/src/main/java/org/crossref/refmatching/ReferenceQuery.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceQuery.java
@@ -1,0 +1,34 @@
+package org.crossref.refmatching;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a distinct reference query object, which includes the
+ * original reference to query, and other values pertinent to the
+ * reference w/respect to the query. Optional values are provided
+ * so that caller-specified values (such as an internal correlation key)
+ * can be echoed back as part of the items returned in a match response.
+ * 
+ * @author joe.aparo
+ */
+public class ReferenceQuery {
+    private final Reference reference;
+    private final Map<String, Object> options = new HashMap<>();
+    
+    public ReferenceQuery(Reference reference) {
+        this.reference = reference;
+    }
+    
+    public Reference getReference() {
+        return reference;
+    }
+    
+    public Object getOption(String key) {
+        return options.get(key);
+    }
+    
+    public void putOption(String key, Object value) {
+        options.put(key, value);
+    }
+}

--- a/src/main/java/org/crossref/refmatching/Utils.java
+++ b/src/main/java/org/crossref/refmatching/Utils.java
@@ -1,14 +1,33 @@
 package org.crossref.refmatching;
 
 import cz.jirutka.unidecode.Unidecode;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import me.xdrop.fuzzywuzzy.FuzzySearch;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.crossref.common.utils.JsonUtils;
+import org.crossref.common.utils.LogUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Utility class.
  * 
  * @author Dominika Tkaczyk
+ * @author Joe Aparo
  */
 public class Utils {
+    
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     public static String normalize(String string) {
         string = Unidecode.toAscii().decode(string).toLowerCase();
@@ -40,4 +59,73 @@ public class Utils {
         }
         return pages;
     }
+    
+    /**
+     * Loads standard headers (mail and Metadata Plus key) from a local file.
+     * The headers will be sent by the API client to the server when making
+     * HTTP calls.
+     *
+     * @param apiKeyFile The path to the key file 
+     * @return A map of headers
+     */
+    public static Map<String, String> createStdHeaders(String apiKeyFile) {
+        String crapiData;
+        try {
+            crapiData = FileUtils.readFileToString(new File(apiKeyFile), "UTF-8");
+        } catch (IOException ex) {
+            LOGGER.warn("Unable to read API key file: " + apiKeyFile);
+            return null;
+        }
+        
+        JSONObject crapiJson = new JSONObject(crapiData);
+        String authorization = crapiJson.optString("Authorization", null);
+        String mailTo = crapiJson.optString("Mailto", null);
+        
+        Map<String, String> stdHeaders = new HashMap();
+        
+         if (!StringUtils.isEmpty(authorization)) {
+            stdHeaders.put("Authorization", authorization);
+        }
+
+        if (!StringUtils.isEmpty(mailTo)) {
+            stdHeaders.put("Mailto", mailTo);
+        }
+        
+        return stdHeaders;
+    }
+    
+    public static List<ReferenceData> parseInputReferences(InputType inputType,
+            String input, String delimiter) throws IOException {
+        String data;
+        if (inputType == InputType.FILE) {
+            data = FileUtils.readFileToString(new File(input), "UTF-8");
+        } else {
+            data = input;
+        }
+        try {
+            JSONArray arr = JsonUtils.createJSONArray(data);
+            List<Object> refs = StreamSupport.stream(arr.spliterator(), true)
+                                    .collect(Collectors.toList());
+            return refs.parallelStream()
+                        .map(s -> (s instanceof String)
+                                ? new Reference((String) s)
+                                : new Reference((JSONObject) s))
+                        .map(r -> new ReferenceData(r))
+                        .collect(Collectors.toList());
+        } catch (JSONException ex) {
+            List<String> strs = Arrays.asList(data.split(delimiter));
+            return strs.parallelStream()
+                    .map(s -> {
+                        try {
+                            JSONObject refObject = new JSONObject(s);
+                            return new Reference(refObject);
+                        } catch (JSONException ex1) {
+                            return new Reference(s);
+                        }
+                    })
+                    .map(r -> new ReferenceData(r))
+                    .collect(Collectors.toList());
+        }
+    }
+    
 }

--- a/src/test/java/org/crossref/refmatching/ReferenceMatcherTest.java
+++ b/src/test/java/org/crossref/refmatching/ReferenceMatcherTest.java
@@ -209,8 +209,9 @@ public class ReferenceMatcherTest {
             when(apiTestClient.getWorks(any(), any()))
                     .thenReturn(extractMockItems(mockJsonFileName));
             
-            MatchRequest request = new MatchRequest(InputType.STRING,
-                    reference.toString());
+            MatchRequest request = new MatchRequest(
+                    Utils.parseInputReferences(InputType.STRING,
+                            reference.toString(), "\r?\n"));
             
             return matcher.match(request);
         } catch (IOException ex) {


### PR DESCRIPTION
A need arose that required introducing new functionality into the reference matcher. The change does not impact the way the application is executed from the command line, but does provide new capability when executing the matcher programmatically.

This feature allows the caller to provide optional values, per individual reference to match. Values provided this way are simply fed back to the caller in the response. These optional properties will assist in tying results from the matcher back into the CS processing pipeline.

Internally, the change introduced a new construct (called a ReferenceQuery) which is now the unit on which the matcher operates. The new object simply contains a Reference to match, as before, as well as optional values that can be attached to it. The existing ReferenceLink result object now contains a ReferenceQuery, instead of a Reference.

The  -it / -i feature is still supported although now, input provided this way is simply mapped to the new implementation.  ReferenceQuery objects can be added to the MatchRequest programmatically as well, without having to use the inputType / inputValue feature, and these two approaches can be combined.