### PR TITLE
Preserve references order

### DIFF
--- a/src/main/java/org/crossref/refmatching/Candidate.java
+++ b/src/main/java/org/crossref/refmatching/Candidate.java
@@ -132,14 +132,14 @@ public class Candidate {
         // weights for author
         if (getAuthor() != null) {
             String a = Utils.normalize(getAuthor());
-            String b = Utils.normalize(refString)
-                    .substring(0, Math.min(3 * a.length(), refString.length()));
+            String b = Utils.normalize(refString);
+            b = b.substring(0, Math.min(3 * a.length(), b.length()));
             similarity.update("author", 1.,
                               Utils.stringSimilarity(a, b, false, true));
         } else if (getEditor() != null) {
             String a = Utils.normalize(getEditor());
-            String b = Utils.normalize(refString)
-                    .substring(0, Math.min(3 * a.length(), refString.length()));
+            String b = Utils.normalize(refString);
+            b = b.substring(0, Math.min(3 * a.length(), b.length()));
             similarity.update("author", 1.,
                               Utils.stringSimilarity(a, b, false, true));
         }

--- a/src/main/java/org/crossref/refmatching/MatchResponse.java
+++ b/src/main/java/org/crossref/refmatching/MatchResponse.java
@@ -55,10 +55,10 @@ public class MatchResponse {
                 r -> {
                     JSONObject result = new JSONObject();
                     result.put("reference",
-                            r.getQuery().getReference().getType().equals(
+                            r.getReferenceData().getReference().getType().equals(
                                     ReferenceType.STRUCTURED) ?
-                            r.getQuery().getReference().getMetadataAsJSON() :
-                            r.getQuery().getReference().getFormattedString());
+                            r.getReferenceData().getReference().getMetadataAsJSON() :
+                            r.getReferenceData().getReference().getFormattedString());
                     result.put("DOI",
                             (r.getDOI() == null) ? JSONObject.NULL : r.getDOI());
                     result.put("score", r.getScore());

--- a/src/main/java/org/crossref/refmatching/ReferenceLink.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceLink.java
@@ -7,12 +7,12 @@ package org.crossref.refmatching;
  */
 public class ReferenceLink {
     
-    private final ReferenceData query;
+    private final ReferenceData referenceData;
     private final String doi;
     private final double score;
 
-    public ReferenceLink(ReferenceData query, String doi, double score) {
-        this.query = query;
+    public ReferenceLink(ReferenceData referenceData, String doi, double score) {
+        this.referenceData = referenceData;
         this.doi = doi;
         this.score = score;
     }
@@ -21,8 +21,8 @@ public class ReferenceLink {
      * Get the original reference query that the item matched on.
      * @return A String representing the reference
      */
-    public ReferenceData getQuery() {
-        return query;
+    public ReferenceData getReferenceData() {
+        return referenceData;
     }
 
     /**

--- a/src/main/java/org/crossref/refmatching/ReferenceMatcher.java
+++ b/src/main/java/org/crossref/refmatching/ReferenceMatcher.java
@@ -83,7 +83,7 @@ public class ReferenceMatcher {
         MatchResponse response = new MatchResponse(request);
         
         // Process the references, which may be a mix of structured/unstructured
-        request.getReferences().parallelStream().forEach(q -> {
+        request.getReferences().parallelStream().forEachOrdered(q -> {
             response.addMatchedLink(
                     q.getReference().getType() == ReferenceType.STRUCTURED ? 
                     matchStructured(q, request) :

--- a/src/test/java/org/crossref/refmatching/CandidateTest.java
+++ b/src/test/java/org/crossref/refmatching/CandidateTest.java
@@ -1,0 +1,147 @@
+package org.crossref.refmatching;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.crossref.common.utils.ResourceUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+/**
+ *
+ * @author Dominika Tkaczyk
+ * @author Joe Aparo
+ */
+public class CandidateTest {
+    private static final double STRING_VALID_TH = 0.34;
+    private static final double STRUCTURED_VALID_TH = 0.65;
+    
+    private final Map<String, String> mockResponseMap = new HashMap<>();
+    
+    @Before
+    public void setupMock() {
+        // Cache mock API responses
+        loadMockResponseMap();
+        
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void candidatePropertiesShouldMatch_whenComparedToThoseGiven() {
+        JSONObject item = extractFirstMockItem("single-doi-response-1.json");
+        Candidate candidate = new Candidate(item);
+        
+        candidate.setValidationScore(0.8);
+
+        Assert.assertEquals(item, candidate.getItem());
+        Assert.assertEquals("10.1007/s10032-015-0249-8", candidate.getDOI());
+        Assert.assertEquals(0.8, candidate.getValidationScore(), 0.0001);
+    }
+    
+    @Test
+    public void similarityShouldCorrespondToScore_whenUnstructuredRefsGiven() {   
+        JSONObject item = extractFirstMockItem("single-doi-response-1.json");
+        item.put("score", 50);
+        Candidate candidate = new Candidate(item);
+
+        Assert.assertTrue(candidate.getStringValidationSimilarity(new Reference(
+            "[1]D. Tkaczyk, P. Szostek, M. Fedoryszak, P. J. Dendek, and Ł. "
+            + "Bolikowski, “CERMINE: automatic extraction of structured "
+            + "metadata from scientific literature,” International Journal "
+            + "on Document Analysis and Recognition (IJDAR), vol. 18, no. 4, "
+            + "pp. 317–335, 2015.")) > STRING_VALID_TH);
+        Assert.assertTrue(candidate.getStringValidationSimilarity(new Reference(
+            "[1] D. Tkaczyk, P. Szostek, M. Fedoryszak, P.J. Dendek, Ł. "
+            + "Bolikowski, International Journal on Document Analysis and "
+            + "Recognition (IJDAR) 18 (2015) 317.")) > STRING_VALID_TH);
+        Assert.assertTrue(candidate.getStringValidationSimilarity(new Reference(
+            "[1]D. Tkaczyk and Ł. Bolikowski, “Extracting Contextual "
+            + "Information from Scientific Literature Using CERMINE System,” "
+            + "Communications in Computer and Information Science, pp. "
+            + "93–104, 2015.")) < STRING_VALID_TH);
+        Assert.assertTrue(candidate.getStringValidationSimilarity(new Reference(
+            "[1] D. Tkaczyk, Ł. Bolikowski, Communications in Computer and "
+            + "Information Science (2015) 93.")) < STRING_VALID_TH);
+        Assert.assertTrue(candidate.getValidationSimilarity(new Reference(
+            "[1]D. Tkaczyk, P. Szostek, M. Fedoryszak, P. J. Dendek, and Ł. "
+            + "Bolikowski,“CERMINE: automatic extraction of structured "
+            + "metadata from scientific literature,” International Journal "
+            + "on Document Analysis and Recognition (IJDAR), vol. 18, no. 4, "
+            + "pp. 317–335, 2015.")) > STRING_VALID_TH);
+        Assert.assertTrue(candidate.getValidationSimilarity(new Reference(
+            "[1] D. Tkaczyk, P. Szostek, M. Fedoryszak, P.J. Dendek, Ł. "
+            + "Bolikowski, International Journal on Document Analysis and "
+            + "Recognition (IJDAR) 18 (2015) 317.")) > STRING_VALID_TH);
+        Assert.assertTrue(candidate.getValidationSimilarity(new Reference(
+            "[1]D. Tkaczyk and Ł. Bolikowski, “Extracting Contextual "
+            + "Information from Scientific Literature Using CERMINE System,” "
+            + "Communications in Computer and Information Science, pp. "
+            + "93–104, 2015.")) < STRING_VALID_TH);
+        Assert.assertTrue(candidate.getValidationSimilarity(new Reference(
+            "[1] D. Tkaczyk, Ł. Bolikowski, Communications in Computer and "
+            + "Information Science (2015) 93.")) < STRING_VALID_TH);
+    }
+    
+    @Test
+    public void similarityShouldCorrespondToScore_whenStructuredRefsGiven() {
+        JSONObject item = extractFirstMockItem("single-doi-response-1.json");    
+        item.put("score", 50);
+        Candidate candidate = new Candidate(item);
+
+        Map<String, String> fields = new HashMap<>();
+        fields.put("author", "Tkaczyk");
+        fields.put("volume", "18");
+        fields.put("first-page", "317");
+        fields.put("year", "2015");
+        fields.put("journal-title", "IJDAR");
+        Reference reference = new Reference(fields);
+
+        Assert.assertTrue(
+            candidate.getStructuredValidationSimilarity(reference)
+                    > STRUCTURED_VALID_TH);
+        Assert.assertTrue(
+            candidate.getValidationSimilarity(reference) > STRUCTURED_VALID_TH);
+
+        fields = new HashMap<>();
+        fields.put("author", "Tkaczyk");
+        fields.put("volume", "93");
+        fields.put("year", "2015");
+        fields.put("journal-title", "Communications in Computer and Information");
+        reference = new Reference(fields);
+
+        Assert.assertTrue(
+            candidate.getStructuredValidationSimilarity(reference)
+                    < STRUCTURED_VALID_TH);
+        Assert.assertTrue(
+            candidate.getValidationSimilarity(reference) < STRUCTURED_VALID_TH);
+    }
+    
+    private JSONArray extractMockItems(String mockJsonFileName) {
+        JSONObject json = new JSONObject(mockResponseMap.get(mockJsonFileName));
+        return json.getJSONObject("message").optJSONArray("items");        
+    }
+    
+    private JSONObject extractFirstMockItem(String mockJsonFileName) {
+        JSONArray items = extractMockItems(mockJsonFileName);
+        return items.getJSONObject(0);
+    }
+    
+    private void loadMockResponseMap() {
+        File[] files = ResourceUtils.getResourceFolderFiles("api-responses");
+        for (File f : files) {
+            try {
+                mockResponseMap.put(f.getName(),
+                        FileUtils.readFileToString(f, "UTF-8"));
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}

--- a/src/test/java/org/crossref/refmatching/ReferenceMatcherTest.java
+++ b/src/test/java/org/crossref/refmatching/ReferenceMatcherTest.java
@@ -119,19 +119,19 @@ public class ReferenceMatcherTest {
         
         Assert.assertEquals(5, response.getMatchedLinks().size());
         Assert.assertEquals("ref1",
-                response.getMatchedLinks().get(0).getQuery()
+                response.getMatchedLinks().get(0).getReferenceData()
                 .getReference().getFormattedString());
         Assert.assertEquals("ref2",
-                response.getMatchedLinks().get(1).getQuery()
+                response.getMatchedLinks().get(1).getReferenceData()
                 .getReference().getFormattedString());
         Assert.assertEquals("{\"ref\":\"3\"}",
-                response.getMatchedLinks().get(2).getQuery()
+                response.getMatchedLinks().get(2).getReferenceData()
                 .getReference().getMetadataAsJSON().toString());
         Assert.assertEquals("ref4",
-                response.getMatchedLinks().get(3).getQuery()
+                response.getMatchedLinks().get(3).getReferenceData()
                 .getReference().getFormattedString());
         Assert.assertEquals("ref5",
-                response.getMatchedLinks().get(4).getQuery()
+                response.getMatchedLinks().get(4).getReferenceData()
                 .getReference().getFormattedString());
     }
     

--- a/src/test/java/org/crossref/refmatching/ReferenceMatcherTest.java
+++ b/src/test/java/org/crossref/refmatching/ReferenceMatcherTest.java
@@ -55,7 +55,7 @@ public class ReferenceMatcherTest {
         reference.put("year", "2015");
         reference.put("journal-title", "IJDAR");
         
-        MatchResponse response = invokeMockStringRequest(reference,
+        MatchResponse response = invokeMockStringRequest(reference.toString(),
                 "structured-ref-response-1.json");
         
         Assert.assertEquals(1, response.getMatchedLinks().size());
@@ -72,7 +72,7 @@ public class ReferenceMatcherTest {
         reference.put("journal-title",
                 "Communications in Computer and Information");
 
-        MatchResponse response = invokeMockStringRequest(reference,
+        MatchResponse response = invokeMockStringRequest(reference.toString(),
                 "structured-ref-response-2.json");
         
         Assert.assertEquals(1, response.getMatchedLinks().size());
@@ -203,7 +203,32 @@ public class ReferenceMatcherTest {
             candidate.getValidationSimilarity(reference) < STRUCTURED_VALID_TH);
     }
     
-    private MatchResponse invokeMockStringRequest(Object reference,
+    @Test
+    public void shouldPreserveReferenceOrder() {
+        String references = "ref1\nref2\n{\"ref\":\"3\"}\nref4\nref5";
+        
+        MatchResponse response = invokeMockStringRequest(references,
+                "unstructured-ref-response-1.json");
+        
+        Assert.assertEquals(5, response.getMatchedLinks().size());
+        Assert.assertEquals("ref1",
+                response.getMatchedLinks().get(0).getQuery()
+                .getReference().getFormattedString());
+        Assert.assertEquals("ref2",
+                response.getMatchedLinks().get(1).getQuery()
+                .getReference().getFormattedString());
+        Assert.assertEquals("{\"ref\":\"3\"}",
+                response.getMatchedLinks().get(2).getQuery()
+                .getReference().getMetadataAsJSON().toString());
+        Assert.assertEquals("ref4",
+                response.getMatchedLinks().get(3).getQuery()
+                .getReference().getFormattedString());
+        Assert.assertEquals("ref5",
+                response.getMatchedLinks().get(4).getQuery()
+                .getReference().getFormattedString());
+    }
+    
+    private MatchResponse invokeMockStringRequest(String reference,
             String mockJsonFileName) {
          try {
             when(apiTestClient.getWorks(any(), any()))
@@ -211,7 +236,7 @@ public class ReferenceMatcherTest {
             
             MatchRequest request = new MatchRequest(
                     Utils.parseInputReferences(InputType.STRING,
-                            reference.toString(), "\r?\n"));
+                            reference, "\r?\n"));
             
             return matcher.match(request);
         } catch (IOException ex) {

--- a/src/test/java/org/crossref/refmatching/ReferenceMatcherTest.java
+++ b/src/test/java/org/crossref/refmatching/ReferenceMatcherTest.java
@@ -24,9 +24,6 @@ import org.mockito.MockitoAnnotations;
  * @author Joe Aparo
  */
 public class ReferenceMatcherTest {
-    private static final double STRING_VALID_TH = 0.34;
-    private static final double STRUCTURED_VALID_TH = 0.65;
-    
     private final Map<String, String> mockResponseMap = new HashMap<>();
     
     @Mock
@@ -111,96 +108,6 @@ public class ReferenceMatcherTest {
         
         Assert.assertEquals(1, response.getMatchedLinks().size());
         Assert.assertNull(response.getMatchedLinks().get(0).getDOI());
-    }
-
-    @Test
-    public void candidatePropertiesShouldMatch_whenComparedToThoseGiven() {
-        JSONObject item = extractFirstMockItem("single-doi-response-1.json");
-        Candidate candidate = new Candidate(item);
-        
-        candidate.setValidationScore(0.8);
-
-        Assert.assertEquals(item, candidate.getItem());
-        Assert.assertEquals("10.1007/s10032-015-0249-8", candidate.getDOI());
-        Assert.assertEquals(0.8, candidate.getValidationScore(), 0.0001);
-    }
-    
-    @Test
-    public void similarityShouldCorrespondToScore_whenUnstructuredRefsGiven() {   
-        JSONObject item = extractFirstMockItem("single-doi-response-1.json");
-        item.put("score", 50);
-        Candidate candidate = new Candidate(item);
-
-        Assert.assertTrue(candidate.getStringValidationSimilarity(new Reference(
-            "[1]D. Tkaczyk, P. Szostek, M. Fedoryszak, P. J. Dendek, and Ł. "
-            + "Bolikowski, “CERMINE: automatic extraction of structured "
-            + "metadata from scientific literature,” International Journal "
-            + "on Document Analysis and Recognition (IJDAR), vol. 18, no. 4, "
-            + "pp. 317–335, 2015.")) > STRING_VALID_TH);
-        Assert.assertTrue(candidate.getStringValidationSimilarity(new Reference(
-            "[1] D. Tkaczyk, P. Szostek, M. Fedoryszak, P.J. Dendek, Ł. "
-            + "Bolikowski, International Journal on Document Analysis and "
-            + "Recognition (IJDAR) 18 (2015) 317.")) > STRING_VALID_TH);
-        Assert.assertTrue(candidate.getStringValidationSimilarity(new Reference(
-            "[1]D. Tkaczyk and Ł. Bolikowski, “Extracting Contextual "
-            + "Information from Scientific Literature Using CERMINE System,” "
-            + "Communications in Computer and Information Science, pp. "
-            + "93–104, 2015.")) < STRING_VALID_TH);
-        Assert.assertTrue(candidate.getStringValidationSimilarity(new Reference(
-            "[1] D. Tkaczyk, Ł. Bolikowski, Communications in Computer and "
-            + "Information Science (2015) 93.")) < STRING_VALID_TH);
-        Assert.assertTrue(candidate.getValidationSimilarity(new Reference(
-            "[1]D. Tkaczyk, P. Szostek, M. Fedoryszak, P. J. Dendek, and Ł. "
-            + "Bolikowski,“CERMINE: automatic extraction of structured "
-            + "metadata from scientific literature,” International Journal "
-            + "on Document Analysis and Recognition (IJDAR), vol. 18, no. 4, "
-            + "pp. 317–335, 2015.")) > STRING_VALID_TH);
-        Assert.assertTrue(candidate.getValidationSimilarity(new Reference(
-            "[1] D. Tkaczyk, P. Szostek, M. Fedoryszak, P.J. Dendek, Ł. "
-            + "Bolikowski, International Journal on Document Analysis and "
-            + "Recognition (IJDAR) 18 (2015) 317.")) > STRING_VALID_TH);
-        Assert.assertTrue(candidate.getValidationSimilarity(new Reference(
-            "[1]D. Tkaczyk and Ł. Bolikowski, “Extracting Contextual "
-            + "Information from Scientific Literature Using CERMINE System,” "
-            + "Communications in Computer and Information Science, pp. "
-            + "93–104, 2015.")) < STRING_VALID_TH);
-        Assert.assertTrue(candidate.getValidationSimilarity(new Reference(
-            "[1] D. Tkaczyk, Ł. Bolikowski, Communications in Computer and "
-            + "Information Science (2015) 93.")) < STRING_VALID_TH);
-    }
-    
-    @Test
-    public void similarityShouldCorrespondToScore_whenStructuredRefsGiven() {
-        JSONObject item = extractFirstMockItem("single-doi-response-1.json");    
-        item.put("score", 50);
-        Candidate candidate = new Candidate(item);
-
-        Map<String, String> fields = new HashMap<>();
-        fields.put("author", "Tkaczyk");
-        fields.put("volume", "18");
-        fields.put("first-page", "317");
-        fields.put("year", "2015");
-        fields.put("journal-title", "IJDAR");
-        Reference reference = new Reference(fields);
-
-        Assert.assertTrue(
-            candidate.getStructuredValidationSimilarity(reference)
-                    > STRUCTURED_VALID_TH);
-        Assert.assertTrue(
-            candidate.getValidationSimilarity(reference) > STRUCTURED_VALID_TH);
-
-        fields = new HashMap<>();
-        fields.put("author", "Tkaczyk");
-        fields.put("volume", "93");
-        fields.put("year", "2015");
-        fields.put("journal-title", "Communications in Computer and Information");
-        reference = new Reference(fields);
-
-        Assert.assertTrue(
-            candidate.getStructuredValidationSimilarity(reference)
-                    < STRUCTURED_VALID_TH);
-        Assert.assertTrue(
-            candidate.getValidationSimilarity(reference) < STRUCTURED_VALID_TH);
     }
     
     @Test


### PR DESCRIPTION
- preserve the order of references in the matching output
- bugfix: index out of bounds in substring
- minor cleanup