### PR TITLE
Synchronize internal list in method MatchResponse.addMatchedLink

### DIFF
--- a/src/main/java/org/crossref/refmatching/MatchResponse.java
+++ b/src/main/java/org/crossref/refmatching/MatchResponse.java
@@ -1,6 +1,7 @@
 package org.crossref.refmatching;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -15,20 +16,23 @@ import org.json.JSONObject;
 public class MatchResponse {
     
     private final MatchRequest request;
-    private final List<ReferenceLink> matchedLinks;
+    private final List<ReferenceLink> matchedLinks = new ArrayList<>();
     
     public MatchResponse(MatchRequest request) {
-        this.matchedLinks = new ArrayList<>();
         this.request = request;
     }
     
     /**
-     * Add a matched link to the result.
+     * Add a matched link to the result. Multiple reference matches
+     * may be executed per request, and are done so using a parallel
+     * stream. Because of this, their results can get added to the
+     * response simultaneously. Therefore, the list is wrapped in a
+     * call to synchronize its update.
      * 
      * @param matchedLink The matched link to add
      */
     public void addMatchedLink(ReferenceLink matchedLink) {
-        matchedLinks.add(matchedLink);
+        Collections.synchronizedList(matchedLinks).add(matchedLink);
     }
 
     /**

--- a/src/main/java/org/crossref/refmatching/MatchResponse.java
+++ b/src/main/java/org/crossref/refmatching/MatchResponse.java
@@ -26,13 +26,13 @@ public class MatchResponse {
      * Add a matched link to the result. Multiple reference matches
      * may be executed per request, and are done so using a parallel
      * stream. Because of this, their results can get added to the
-     * response simultaneously. Therefore, the list is wrapped in a
-     * call to synchronize its update.
+     * response simultaneously. Therefore, access to this method is
+     * synchronized.
      * 
      * @param matchedLink The matched link to add
      */
-    public void addMatchedLink(ReferenceLink matchedLink) {
-        Collections.synchronizedList(matchedLinks).add(matchedLink);
+    public synchronized void addMatchedLink(ReferenceLink matchedLink) {
+        matchedLinks.add(matchedLink);
     }
 
     /**

--- a/src/test/java/org/crossref/refmatching/MatchResponseTest.java
+++ b/src/test/java/org/crossref/refmatching/MatchResponseTest.java
@@ -1,0 +1,25 @@
+package org.crossref.refmatching;
+
+import java.util.stream.IntStream;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ *
+ * @author Dominika Tkaczyk
+ */
+public class MatchResponseTest {
+
+    @Test
+    public void testSynchronizedAddMatchedLink() {
+        MatchResponse response = new MatchResponse(null);
+        IntStream.range(0, 1000).parallel()
+                .forEach(n -> {
+                    for (int i = 0; i < 100; i++) {
+                        response.addMatchedLink(null);
+                    }
+                });
+        assertEquals(100000, response.getMatchedLinks().size());
+    }
+
+}


### PR DESCRIPTION
Because multiple reference matches per request are executed in parallel, results can get added to the response simultaneously.  So in the addMatchedLink method, the update of the internal list was synchronized.